### PR TITLE
Update command options

### DIFF
--- a/docs/guide/structures/Command.md
+++ b/docs/guide/structures/Command.md
@@ -554,13 +554,13 @@ module.exports = class PingCommand extends Command {
         {
           name: "name",
           description: "description",
-          type: "STRING",
+          type: 3,
           autocomplete: true,
         },
         {
           name: "theme",
           description: "description",
-          type: "STRING",
+          type: 3,
           autocomplete: true,
         },
       ],
@@ -612,13 +612,13 @@ export class PingCommand extends Command {
         {
           name: "name",
           description: "description",
-          type: "STRING",
+          type: 3,
           autocomplete: true,
         },
         {
           name: "theme",
           description: "description",
-          type: "STRING",
+          type: 3,
           autocomplete: true,
         },
       ],


### PR DESCRIPTION
Changed "STRING" to 3 for ApplicationCommandOptionType (https://discord-api-types.dev/api/discord-api-types-v10/enum/ApplicationCommandOptionType) since it changed in DJS 14